### PR TITLE
Support path based routing in dev-server

### DIFF
--- a/src/dev-server/http-server.ts
+++ b/src/dev-server/http-server.ts
@@ -45,6 +45,9 @@ export function createHttpServer(config: ServeConfig): express.Application {
   app.get('/cordova_plugins.js', servePlatformResource);
   app.get('/plugins/*', servePlatformResource);
 
+  // Fallback route - send to index.html to allow deeplinker to handle path.
+  app.get('*', serveIndex);
+
   if (config.useProxy) {
     setupProxies(app);
   }

--- a/src/dev-server/http-server.ts
+++ b/src/dev-server/http-server.ts
@@ -46,7 +46,7 @@ export function createHttpServer(config: ServeConfig): express.Application {
   app.get('/plugins/*', servePlatformResource);
 
   // Fallback route - send to index.html to allow deeplinker to handle path.
-  app.get('*', serveIndex);
+  app.use(serveIndex);
 
   if (config.useProxy) {
     setupProxies(app);

--- a/src/dev-server/injector.ts
+++ b/src/dev-server/injector.ts
@@ -38,7 +38,7 @@ function getDevLoggerScript(rootDir: string, notifyOnConsoleLog: boolean, notifi
   return `
   ${LOGGER_HEADER}
   <script>var IonicDevServerConfig=${ionDevServer};</script>
-  <link href="${LOGGER_DIR}/ion-dev.css?v=${appScriptsVersion}" rel="stylesheet">
-  <script src="${LOGGER_DIR}/ion-dev.js?v=${appScriptsVersion}"></script>
+  <link href="/${LOGGER_DIR}/ion-dev.css?v=${appScriptsVersion}" rel="stylesheet">
+  <script src="/${LOGGER_DIR}/ion-dev.js?v=${appScriptsVersion}"></script>
   `;
 }

--- a/src/dev-server/injector.ts
+++ b/src/dev-server/injector.ts
@@ -38,7 +38,7 @@ function getDevLoggerScript(rootDir: string, notifyOnConsoleLog: boolean, notifi
   return `
   ${LOGGER_HEADER}
   <script>var IonicDevServerConfig=${ionDevServer};</script>
-  <link href="/${LOGGER_DIR}/ion-dev.css?v=${appScriptsVersion}" rel="stylesheet">
-  <script src="/${LOGGER_DIR}/ion-dev.js?v=${appScriptsVersion}"></script>
+  <link href="${LOGGER_DIR}/ion-dev.css?v=${appScriptsVersion}" rel="stylesheet">
+  <script src="${LOGGER_DIR}/ion-dev.js?v=${appScriptsVersion}"></script>
   `;
 }


### PR DESCRIPTION
#### Short description of what this resolves:

Assuming you wish to use the path location strategy in the Ionic app
```
locationStrategy: 'path'
```
and are running `ionic serve`.
Currently you can load your index page and navigate around fine. The path in the browser is updated to `/about` for example. However if you refresh this `/about` page, you get a 404 because that path does not exist.

#### Changes proposed in this pull request:

Added a catchall route so that 404 will get sent to the index page and the Ionic deeplinker can handle routing to the `about` segment.
