### PR TITLE
fix(sass): fix .sass files not being watched

### DIFF
--- a/src/watch.ts
+++ b/src/watch.ts
@@ -331,9 +331,9 @@ export function runBuildUpdate(context: BuildContext, changedFiles: ChangedFile[
   }
 
 
-  const sassFiles = changedFiles.filter(f => f.ext === '.scss');
+  const sassFiles = changedFiles.filter(f => /^\.s(c|a)ss$/.test(f.ext));
   if (sassFiles.length) {
-    // .scss file was changed/added/deleted, lets do a sass update
+    // .scss or .sass file was changed/added/deleted, lets do a sass update
     context.sassState = BuildState.RequiresUpdate;
   }
 


### PR DESCRIPTION
#### Short description of what this resolves:
`.sass` files are built but not watched, it means we need to relaunch `serve` each time a sass file is changed.

#### Changes proposed in this pull request:

- Watch `*.sass` files on top of `*.scss` files