### PR TITLE
patch for passing params from lab to iframes

### DIFF
--- a/lab/static/js/lab.js
+++ b/lab/static/js/lab.js
@@ -48,6 +48,13 @@ function showDevice(device, isShowing) {
     var template = $('#' + device + '-frame-template');
     var clone = document.importNode(template, true);
     $('preview').appendChild(clone.content);
+    //check for extra params in location.url to pass on to iframes
+    var params = document.location.href.split('?')
+    if (params) {
+      var newparams = params[params.length - 1]
+      var oldsrc = $('preview .frame').getAttribute('src')
+      $('preview .frame').setAttribute('src', oldsrc + '&' + newparams)
+    }
   } else {
     rendered.style.display = isShowing ? '' : 'none';
   }


### PR DESCRIPTION
#### Short description of what this resolves:
It seems that, when you start ionic in labs mode with --lab, you do not have the possibility to pass config options by extending the url with ?ionicsomesetting=1, which you would normally get in your app with config.get('somesetting').

this patch passes the parameters on to the individual iframes in lab mode.

**Fixes**: #2431
