### PR TITLE
switched order of js & ts extensions in webpack.config

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -13,7 +13,7 @@ module.exports = {
   devtool: process.env.IONIC_SOURCE_MAP_TYPE,
 
   resolve: {
-    extensions: ['.ts', '.js', '.json'],
+    extensions: ['.js', '.ts', '.json'],
     modules: [path.resolve('node_modules')]
   },
 


### PR DESCRIPTION
#### Short description of what this resolves:
I was having an issue with angular2-notifications and it was suggested to switch the order of extensions in the webpack.config.js file:

https://github.com/flauc/angular2-notifications/issues/134

#### Changes proposed in this pull request:

Switching the order of extensions in the config.webpack.js file.

```
File: node_modules\@ionic\app-scripts\config\webpack.config.js
15:   resolve: {
16:     extensions: ['.js', '.ts', '.json'],
17:     modules: [path.resolve('node_modules')]
18:   },

```

I am not sure what the knock on effects this would have, but it fixed the notification issue and didn't give any other errors on `ionic cordova run android --prod`