### PR TITLE
Fix config param naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ npm run build --rollup ./config/rollup.config.js
 | convert bundle to ES5 | `ionic_build_to_es5` | `--buildToEs5` | `true` | Convert bundle to ES5 for for production deployments |
 | default watch timeout | `ionic_start_watch_timeout` | `--startWatchTimeout` | `3000` | Milliseconds controlling the default watch timeout |
 | choose the polyfill  | `ionic_polyfill_name` | `--polyfillName` | `polyfills` | Change with polyfills.modern or polyfills.ng (all options)[https://github.com/driftyco/ionic/tree/master/scripts/polyfill] |
-| enable linting | `enable_lint` | `--enableLint` | `true` | Set to `false` for skipping the linting after the build |
+| enable linting | `ionic_enable_lint` | `--enableLint` | `true` | Set to `false` for skipping the linting after the build |
 
 
 


### PR DESCRIPTION
The config parameter is named `ionic_enable_lint`, not `enable_lint`
