### PR TITLE
fix(generators): no module by default

### DIFF
--- a/src/generators/util.ts
+++ b/src/generators/util.ts
@@ -12,7 +12,7 @@ import { ensureSuffix, removeSuffix } from '../util/helpers';
 import { appendNgModuleDeclaration, insertNamedImportIfNeeded } from '../util/typescript-utils';
 
 export function hydrateRequest(context: BuildContext, request: GeneratorRequest) {
-  const hydrated = Object.assign({ includeNgModule: true }, request) as HydratedGeneratorRequest;
+  const hydrated = Object.assign({ includeNgModule: false }, request) as HydratedGeneratorRequest;
   const suffix = getSuffixFromGeneratorType(context, request.type);
 
   hydrated.className = ensureSuffix(pascalCase(request.name), upperCaseFirst(suffix));


### PR DESCRIPTION
#### Short description of what this resolves:
By default, `generate` will make a NgModule by default, Since we do not ship lazy loading by default, we should not generate this right now. 

#### Changes proposed in this pull request:

-  set`includeNgModule` to false for now.
