### PR TITLE
Fix for #701

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ export * from './util/constants';
 export * from './generators';
 
 import { generateContext } from './util/config';
-import { getAppScriptsVersion } from './util/helpers';
+import { getAppScriptsVersion, setContext } from './util/helpers';
 import { Logger } from './logger/logger';
 
 export function run(task: string) {
@@ -28,6 +28,7 @@ export function run(task: string) {
 
   try {
     const context = generateContext(null);
+    setContext(context);
     require(`../dist/${task}`)[task](context).catch((err: any) => {
       errorLog(task, err);
     });


### PR DESCRIPTION
#### Short description of what this resolves:
This resolves the issue that certain tasks that only run a part of the build chain no longer worked (see issue #701) 

#### Changes proposed in this pull request:

I moved the call to setContext to the run method, so it is executed for all commands. 
