### PR TITLE
feat(webpack): Pull js filename from config

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ npm run build --rollup ./config/rollup.config.js
 | app ng module path | `ionic_app_ng_module_path`  | `--appNgModulePath` | `{{srcDir}}/app/app.module.ts` | absolute path to app's primary `NgModule` |
 | app ng module class | `ionic_app_ng_module_class`  | `--appNgModuleClass` | `AppModule` | Exported class name for app's primary `NgModule` |
 | clean before copy | `ionic_clean_before_copy`  | `--cleanBeforeCopy` | `false` | clean out existing files before copy task runs |
-| output js file | `ionic_output_js_file_name`  | `--outputJsFileName` | `main.js` | name of js file generated in `buildDir` |
+| output js file | `ionic_output_js_file_name`  | `--outputJsFileName` | `[name].js` | name of js file generated in `buildDir` |
 | output css file | `ionic_output_css_file_name`  | `--outputCssFileName` | `main.css` | name of css file generated in `buildDir` |
 | bail on lint error | `ionic_bail_on_lint_error`  | `--bailOnLintError` | `null` | Set to `true` to make stand-alone lint commands fail with non-zero status code |
 | enable type checking during lint | `ionic_type_check_on_lint`  | `--typeCheckOnLint` | `null` | Set to `true` to enable [type checking](https://palantir.github.io/tslint/usage/type-checking) during lint |

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -14,7 +14,7 @@ module.exports = {
   output: {
     path: '{{BUILD}}',
     publicPath: 'build/',
-    filename: '[name].js',
+    filename: process.env.IONIC_OUTPUT_JS_FILE_NAME,
     devtoolModuleFilenameTemplate: ionicWebpackFactory.getSourceMapperFunction(),
   },
   devtool: process.env.IONIC_SOURCE_MAP_TYPE,

--- a/src/util/config.spec.ts
+++ b/src/util/config.spec.ts
@@ -100,7 +100,7 @@ describe('config', () => {
       expect(fakeConfig[Constants.ENV_GLOB_UTIL]).toEqual(join(fakeConfig[Constants.ENV_VAR_APP_SCRIPTS_DIR], 'dist', 'util', 'glob-util.js'));
       expect(fakeConfig[Constants.ENV_CLEAN_BEFORE_COPY]).toBeFalsy();
       expect(fakeConfig[Constants.ENV_CLOSURE_JAR]).toEqual(join(fakeConfig[Constants.ENV_VAR_APP_SCRIPTS_DIR], 'bin', 'closure-compiler.jar'));
-      expect(fakeConfig[Constants.ENV_OUTPUT_JS_FILE_NAME]).toEqual('main.js');
+      expect(fakeConfig[Constants.ENV_OUTPUT_JS_FILE_NAME]).toEqual('[name].js');
       expect(fakeConfig[Constants.ENV_OUTPUT_CSS_FILE_NAME]).toEqual('main.css');
       expect(fakeConfig[Constants.ENV_WEBPACK_FACTORY]).toEqual(join(fakeConfig[Constants.ENV_VAR_APP_SCRIPTS_DIR], 'dist', 'webpack', 'ionic-webpack-factory.js'));
       expect(fakeConfig[Constants.ENV_WEBPACK_LOADER]).toEqual(join(fakeConfig[Constants.ENV_VAR_APP_SCRIPTS_DIR], 'dist', 'webpack', 'loader.js'));

--- a/src/util/config.ts
+++ b/src/util/config.ts
@@ -209,7 +209,7 @@ export function generateContext(context?: BuildContext): BuildContext {
   setProcessEnvVar(Constants.ENV_CLOSURE_JAR, closureCompilerJarPath);
   Logger.debug(`closureCompilerJarPath set to ${closureCompilerJarPath}`);
 
-  context.outputJsFileName = getConfigValue(context, '--outputJsFileName', null, Constants.ENV_OUTPUT_JS_FILE_NAME, Constants.ENV_OUTPUT_JS_FILE_NAME.toLowerCase(), 'main.js');
+  context.outputJsFileName = getConfigValue(context, '--outputJsFileName', null, Constants.ENV_OUTPUT_JS_FILE_NAME, Constants.ENV_OUTPUT_JS_FILE_NAME.toLowerCase(), '[name].js');
   setProcessEnvVar(Constants.ENV_OUTPUT_JS_FILE_NAME, context.outputJsFileName);
   Logger.debug(`outputJsFileName set to ${context.outputJsFileName}`);
 


### PR DESCRIPTION
#### Short description of what this resolves:
This allows users to set their own main.js filename.
Currently this is not possible even though it says it is in the readme.md file.

#### Changes proposed in this pull request:

- Rename the default output_js_filename to `[name].js`
- Use the environment variable to set the output filename
-

**Fixes**: #1163
