### PR TITLE
change default pipe dir name from PIPES to pipes

### DIFF
--- a/src/util/config.ts
+++ b/src/util/config.ts
@@ -185,7 +185,7 @@ export function generateContext(context?: BuildContext): BuildContext {
   setProcessEnvVar(Constants.ENV_COMPONENTS_NG_MODULE_PATH, context.componentsNgModulePath);
   Logger.debug(`componentsNgModulePath set to ${context.componentsNgModulePath}`);
 
-  context.pipesNgModulePath = resolve(getConfigValue(context, '--pipesNgModulePath', null, Constants.ENV_PIPES_NG_MODULE_PATH, Constants.ENV_PIPES_NG_MODULE_PATH.toLowerCase(), join(context.srcDir, 'PIPES', 'pipes.module.ts')));
+  context.pipesNgModulePath = resolve(getConfigValue(context, '--pipesNgModulePath', null, Constants.ENV_PIPES_NG_MODULE_PATH, Constants.ENV_PIPES_NG_MODULE_PATH.toLowerCase(), join(context.srcDir, 'pipes', 'pipes.module.ts')));
   setProcessEnvVar(Constants.ENV_PIPES_NG_MODULE_PATH, context.pipesNgModulePath);
   Logger.debug(`pipesNgModulePath set to ${context.pipesNgModulePath}`);
 


### PR DESCRIPTION
#### Short description of what this resolves:
Fixes the "no such file or directory" error while generating pipes.
Problem was the uppercase PIPES dir in the path for generating the pipes.module.ts file

**Fixes**: [#2621](https://github.com/ionic-team/ionic-cli/issues/2621)