### PR TITLE
fix --nolivereload flag not work bug

### DIFF
--- a/src/dev-server/http-server.ts
+++ b/src/dev-server/http-server.ts
@@ -84,9 +84,8 @@ function serveIndex(req: express.Request, res: express.Response)  {
   fs.readFile(indexFileName, (err, indexHtml) => {
     if (config.useLiveReload) {
       indexHtml = injectLiveReloadScript(indexHtml, req.hostname, config.liveReloadPort);
+      indexHtml = injectNotificationScript(config.rootDir, indexHtml, config.notifyOnConsoleLog, config.notificationPort);
     }
-
-    indexHtml = injectNotificationScript(config.rootDir, indexHtml, config.notifyOnConsoleLog, config.notificationPort);
 
     indexHtml = injectDiagnosticsHtml(config.buildDir, indexHtml);
 


### PR DESCRIPTION
#### Short description of what this resolves:
This commit fix the problem that the `--nolivereload` or `-d` flag doesn't work when user excute `ionic serve -d` or `ionic serve --nolivereload` command with ion-cli

#### Changes proposed in this pull request:

- The `injectNotificationScript` can be executed, only when user set a true value for `config.useLiveReload`

**Fixes**: #
