### PR TITLE
TSLint: add ability to exclude files and folders

### DIFF
--- a/config/tslint.config.js
+++ b/config/tslint.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+
+  tsLintConfig: './tslint.json',
+
+  exclude: [
+    '**/node_modules/**/*'
+  ]
+
+}

--- a/src/lint/lint-factory.ts
+++ b/src/lint/lint-factory.ts
@@ -1,5 +1,6 @@
 import { Configuration, Linter, LintResult } from 'tslint';
 import { Program, getPreEmitDiagnostics, Diagnostic } from 'typescript';
+import * as glob from 'glob';
 import { BuildContext } from '../util/interfaces';
 import { isObject } from 'util';
 
@@ -64,10 +65,18 @@ export function createProgram(context: BuildContext, tsConfig: string): Program 
  * Get all files that are sourced in TS config
  * @param {BuildContext} context
  * @param {Program} program
+ * @param {Array<string>} excludePatterns
  * @return {Array<string>}
  */
-export function getFileNames(context: BuildContext, program: Program): string[] {
-  return Linter.getFileNames(program);
+export function getFileNames(context: BuildContext, program: Program, excludePatterns?: string[]): string[] {
+  let files: string[] = Linter.getFileNames(program);
+  if (excludePatterns) {
+    const globOptions = { ignore: excludePatterns, nodir: true };
+    files = files
+      .map((file: string) => glob.sync(file, globOptions))
+      .reduce((a: string[], b: string[]) => a.concat(b), []);
+  }
+  return files;
 }
 
 


### PR DESCRIPTION
#### Short description of what this resolves:

After upgrade to Ionic 3, **tslint** shows errors even for external typescript libraries inside the `node_modules` folder.

#### Changes proposed in this pull request:

- Change `envVar` option value to upper case (`ionic_tslint` -> `IONIC_TSLINT`) (as the rest of functionalities)
- Change `packageConfig` option value to lower case (`IONIC_TSLINT` -> `ionic_tslint`) according to the docs [Overriding Config Files](https://github.com/ionic-team/ionic-app-scripts#overriding-config-files)
- Add ability to override config file for linter (actually, the package config setting is only used to specify the `tslint.json` to be used. Now allows you to:
  - Exclude files and folders from the linter by setting glob patterns
  - Specify the `tslint.json` file that is used.


**Fixes**: #1203
