### PR TITLE
Added a cokieRewrite option which is passed to proxy-middleware.

### DIFF
--- a/src/dev-server/http-server.ts
+++ b/src/dev-server/http-server.ts
@@ -63,6 +63,7 @@ function setupProxies(app: express.Application) {
         }
 
         opts.rejectUnauthorized = !(proxy.rejectUnauthorized === false);
+        opts.cookieRewrite = proxy.cookieRewrite;
 
         app.use(proxy.path, proxyMiddleware(opts));
         Logger.info('Proxy added:' + proxy.path + ' => ' + url.format(opts));

--- a/src/util/ionic-project.ts
+++ b/src/util/ionic-project.ts
@@ -10,7 +10,8 @@ export interface IonicProject {
     path: string,
     proxyUrl: string,
     proxyNoAgent: boolean,
-    rejectUnauthorized: boolean
+    rejectUnauthorized: boolean,
+    cookieRewrite: string | boolean,
   }[];
 }
 


### PR DESCRIPTION
This allows cookies to be forwarded correctly when using a proxy
to an HTTPS URL.

Related:
* ionic-team/ionic-app-scripts#454
* ionic-team/ionic-cli#415

#### Short description of what this resolves:

This resolves an issue where cookies are not forwarded when a proxy to an HTTPS URL is used. This has been discussed in the past, but a corresponding PR has been closed without any explanation (alongside the ticket).

I'm not really in knowledgeable in this area, so if this change is problematic, we should at least clarify why and how it could be solved otherwise. 

#### Changes proposed in this pull request:

- Add a `cookieRewrite` option to the proxy configuration which is passed to proxy-middleware.

**Fixes**:

* ionic-team/ionic-cli#415
* Possibly ionic-team/ionic-app-scripts#454 ?