### PR TITLE
Fix template loading

### DIFF
--- a/src/template.ts
+++ b/src/template.ts
@@ -176,7 +176,7 @@ export function getTemplateFormat(htmlFilePath: string, content: string) {
   content = content.replace(/\r|\n/g, '\\n');
   content = content.replace(/\'/g, '\\\'');
 
-  return `${getTemplatePrefix(htmlFilePath)}'${content}'${getTemplateSuffix(htmlFilePath)}`;
+  return `${getTemplatePrefix(htmlFilePath)}\`${content}\`${getTemplateSuffix(htmlFilePath)}`;
 }
 
 


### PR DESCRIPTION
Fix template loading when html element attribute is object and string value contain antislash

#### Short description of what this resolves:


#### Changes proposed in this pull request:

-
-
-

**Fixes**: #
