### PR TITLE
fix(node-sass): Node 9.0 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "fs-extra": "^4.0.2",
     "glob": "^7.1.2",
     "json-loader": "^0.5.7",
-    "node-sass": "^4.5.3",
+    "node-sass": "^4.6.0",
     "os-name": "^2.0.1",
     "postcss": "^6.0.13",
     "proxy-middleware": "^0.15.0",


### PR DESCRIPTION
#### Short description of what this resolves:
This  PR upgrades node-sass to support Node.js 9.0

**Fixes**: #1303
