### PR TITLE
Provide the PathLocationStrategy in development mode

### DIFF
--- a/src/dev-server/http-server.ts
+++ b/src/dev-server/http-server.ts
@@ -50,6 +50,10 @@ export function createHttpServer(config: ServeConfig): express.Application {
     setupProxies(app);
   }
 
+  if (config.isPathLocationStrategy) {
+    app.all('/*', serveIndex);
+  }
+
   return app;
 }
 

--- a/src/dev-server/serve-config.ts
+++ b/src/dev-server/serve-config.ts
@@ -18,6 +18,7 @@ export interface ServeConfig {
   notifyOnConsoleLog: boolean;
   useProxy: boolean;
   devapp: boolean;
+  isPathLocationStrategy: boolean;
 }
 export const LOGGER_DIR = '__ion-dev-server';
 export const IONIC_LAB_URL = '/ionic-lab';

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -46,7 +46,8 @@ export function serve(context: BuildContext) {
         useServerLogs: useServerLogs(context),
         useProxy: useProxy(context),
         notifyOnConsoleLog: sendClientConsoleLogs(context),
-        devapp: false
+        devapp: false,
+        isPathLocationStrategy: isPathLocationStrategy(context)
       };
 
       createNotificationServer(config);
@@ -162,4 +163,8 @@ function useProxy(context: BuildContext): boolean {
 
 function sendClientConsoleLogs(context: BuildContext): boolean {
   return hasConfigValue(context, '--consolelogs', '-c', 'ionic_consolelogs', false);
+}
+
+function isPathLocationStrategy(context: BuildContext): boolean {
+  return hasConfigValue(context, '--pathlocationstrategy', null, 'ionic_pathlocationstrategy', false);
 }


### PR DESCRIPTION
#### Short description of what this resolves:
With **--pathlocationstrategy** e.g. `npm run ionic-app-scripts serve --pathlocationstrategy` you can now use the PathLocationStrategy. This means you can refresh on a route like this: http://localhost:8100/dashboard/my-feature without a server error and loading the correct view of the route without the need to open http://localhost:8100/#/dashboard/my-feature with the HashLocationStrategy.

#### Changes proposed in this pull request:

- Add a command line flag for enabling the PathLocationStrategy in development mode.
- If this flag is enabled, reroute any requests to serveIndex => e.g. index.html

**Fixes**: #10565
