### PR TITLE
Fixed https://github.com/ionic-team/ionic/issues/13718

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "tiny-lr": "^1.0.5",
     "tslint": "^5.8.0",
     "tslint-eslint-rules": "^4.1.1",
-    "uglify-es": "^3.2.0",
+    "uglify-es": "3.2.2",
     "webpack": "3.8.1",
     "ws": "3.3.2",
     "xml2js": "^0.4.19"


### PR DESCRIPTION
#### Short description of what this resolves:

New uglify-es@3.3.2 stable version breaks all ionic/angular --prod builds https://github.com/mishoo/UglifyJS2/issues/2664 https://github.com/mishoo/UglifyJS2/issues/2663

#### Changes proposed in this pull request:

For a while I propose to pin unglify-es@3.2.2 version to restore normal build.

**Fixes**: https://github.com/ionic-team/ionic/issues/13718
