### PR TITLE
use wss: protocol for secure websocket when page is using https:

### DIFF
--- a/bin/ion-dev.js
+++ b/bin/ion-dev.js
@@ -98,7 +98,8 @@ window.IonicDevServer = {
 
   openConnection: function() {
     var self = this;
-    this.socket = new WebSocket('ws://' + window.location.hostname + ':' + IonicDevServerConfig.wsPort);
+    var socketProtocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+    this.socket = new WebSocket(socketProtocol + '//' + window.location.hostname + ':' + IonicDevServerConfig.wsPort);
 
     this.socket.onopen = function(ev) {
       self.socketReady = true;


### PR DESCRIPTION
#### Short description of what this resolves:
When using an https (and wss) reverse proxy for the browser platform, the hardcoded ws protocol WebSocket connection gives a Mixed Content error.

#### Changes proposed in this pull request:

- attempt to connect to the WebSocket with wss when the page is on https

I know there is some work being done towards better support for https in development environments (see [https://github.com/ionic-team/ionic/issues/1686]()) but I'm wondering if this small change would be acceptable as a stop-gap?
