### PR TITLE
Adding regex for Webpack to fix "Critical dependency" warning

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -91,6 +91,11 @@ var devConfig = {
   },
 
   plugins: [
+    new webpack.ContextReplacementPlugin(
+      /(ionic-angular)|(angular(\\|\/)core(\\|\/)@angular)/,
+      root('./src'), // location of your src
+      {} // a map of your routes
+    ),
     ionicWebpackFactory.getIonicEnvironmentPlugin(),
     ionicWebpackFactory.getCommonChunksPlugin()
   ],


### PR DESCRIPTION
#### Short description of what this resolves:
Fix the issue https://github.com/ionic-team/ionic/issues/11072

#### Changes proposed in this pull request:
Fix the webpack configuration to avoid warnings from the ionic side

**Fixes**: #11072
