### PR TITLE
Remove PostCSS warning

### DIFF
--- a/src/sass.ts
+++ b/src/sass.ts
@@ -281,7 +281,8 @@ function renderSassSuccess(context: BuildContext, sassResult: Result, sassConfig
 
     const postcssOptions: any = {
       to: basename(sassConfig.outFile),
-      map: autoPrefixerMapOptions
+      map: autoPrefixerMapOptions,
+      from: void 0
     };
 
     Logger.debug(`sass, start postcss/autoprefixer`);


### PR DESCRIPTION
This removes following warning:

Remove warning: Without `from` option PostCSS could generate wrong source map or do not find Browserslist config. Set it to CSS file path or to `undefined` to prevent this warning

`from: the input file name (most runners set it automatically).`
Source: https://github.com/postcss/postcss

Fixes #1359 #13763
https://github.com/ionic-team/ionic-app-scripts/issues/1359
https://github.com/ionic-team/ionic/issues/13763

#### Short description of what this resolves:
This removes the PostCSS warning, which is resulting in an error in our automated builds.

#### Changes proposed in this pull request:

- Just add `from` field with an undefined value, as mentioned in the warning.

**Fixes**:  #1359 #13763
