### PR TITLE
add more directory to ANDROID_PLATFORM_PATH

### DIFF
--- a/src/dev-server/serve-config.ts
+++ b/src/dev-server/serve-config.ts
@@ -23,4 +23,4 @@ export const LOGGER_DIR = '__ion-dev-server';
 export const IONIC_LAB_URL = '/ionic-lab';
 
 export const IOS_PLATFORM_PATH = path.join('platforms', 'ios', 'www');
-export const ANDROID_PLATFORM_PATH = path.join('platforms', 'android', 'assets', 'www');
+export const ANDROID_PLATFORM_PATH = path.join('platforms', 'android', 'app', 'src', 'main', 'assets', 'www');


### PR DESCRIPTION
#### Short description of what this resolves:

There is a bug when we run `ionic cordova run/emulate android --livereload`, somehow the system won't notice that cordova is available on the device. This fix will allow the system to notice that cordova is available when using `--livereload`.

The fix method is taken from https://github.com/ionic-team/ionic-cli/issues/2973.

#### Changes proposed in this pull request:

- Change the ANDROID_PLATFORM_PATH from `export const ANDROID_PLATFORM_PATH = path.join('platforms', 'android', 'assets', 'www');`
- Replace it with `export const ANDROID_PLATFORM_PATH = path.join('platforms', 'android', 'app', 'src', 'main', 'assets', 'www');`

#### Fixes: #1391 