### PR TITLE
fix(sourcemaps) copy vendor.js.map

### DIFF
--- a/src/util/source-maps.ts
+++ b/src/util/source-maps.ts
@@ -15,7 +15,7 @@ export async function copySourcemaps(context: BuildContext, shouldPurge: boolean
   // only include js source maps
   const sourceMaps = fileNames.filter(fileName => fileName.endsWith('.map'));
 
-  const toCopy = sourceMaps.filter(fileName => fileName.indexOf('vendor.js') < 0 && fileName.endsWith('.js.map'));
+  const toCopy = sourceMaps.filter(fileName => fileName.endsWith('.js.map'));
   const toCopyFullPaths = toCopy.map(fileName => join(context.buildDir, fileName));
 
   const toPurge = sourceMaps.map(sourceMap => join(context.buildDir, sourceMap));


### PR DESCRIPTION
#### Short description of what this resolves:
Keep vendor.js.map instead of ignoring it

#### Changes proposed in this pull request:

- For unkown (and uncommented) reason, vendor.js.map was skipped on sourcemaps copy
- I removed this filtering
-

**Fixes**: # might partially fix https://github.com/ionic-team/ionic-app-scripts/issues/1235 (for the missing vendor part)
