### PR TITLE
fix(live-server): update android platform path

### DIFF
--- a/src/dev-server/http-server.ts
+++ b/src/dev-server/http-server.ts
@@ -8,8 +8,8 @@ import {
   ServeConfig,
   LOGGER_DIR,
   IONIC_LAB_URL,
-  IOS_PLATFORM_PATH,
-  ANDROID_PLATFORM_PATH
+  IOS_PLATFORM_PATHS,
+  ANDROID_PLATFORM_PATHS
 } from './serve-config';
 import { Logger } from '../logger/logger';
 import * as proxyMiddleware from 'proxy-middleware';
@@ -36,7 +36,7 @@ export function createHttpServer(config: ServeConfig): express.Application {
   // Lab routes
   app.use(IONIC_LAB_URL + '/static', express.static(path.join(__dirname, '..', '..', 'lab', 'static')));
   app.get(IONIC_LAB_URL, LabAppView);
-  app.get(IONIC_LAB_URL + '/api/v1/cordova', ApiCordovaProject );
+  app.get(IONIC_LAB_URL + '/api/v1/cordova', ApiCordovaProject);
   app.get(IONIC_LAB_URL + '/api/v1/app-config', ApiPackageJson);
 
   app.get('/cordova.js', servePlatformResource, serveMockCordovaJS);
@@ -52,7 +52,7 @@ export function createHttpServer(config: ServeConfig): express.Application {
 
 function setupProxies(app: express.Application) {
   if (getBooleanPropertyValue(Constants.ENV_READ_CONFIG_JSON)) {
-    getProjectJson().then(function(projectConfig: IonicProject) {
+    getProjectJson().then(function (projectConfig: IonicProject) {
       for (const proxy of projectConfig.proxies || []) {
         let opts: any = url.parse(proxy.proxyUrl);
         if (proxy.proxyNoAgent) {
@@ -74,7 +74,7 @@ function setupProxies(app: express.Application) {
 /**
  * http responder for /index.html base entrypoint
  */
-function serveIndex(req: express.Request, res: express.Response)  {
+function serveIndex(req: express.Request, res: express.Response) {
   const config: ServeConfig = req.app.get('serveConfig');
 
   // respond with the index.html file
@@ -108,37 +108,64 @@ function serveMockCordovaJS(req: express.Request, res: express.Response) {
 /**
  * Middleware to serve platform resources
  */
-function servePlatformResource(req: express.Request, res: express.Response, next: express.NextFunction) {
+async function servePlatformResource(req: express.Request, res: express.Response, next: express.NextFunction) {
   const config: ServeConfig = req.app.get('serveConfig');
   const userAgent = req.header('user-agent');
-  let resourcePath = config.wwwDir;
 
   if (!config.isCordovaServe) {
     return next();
   }
 
+  let root = await getResourcePath(req.url, config, userAgent);
+  if (root) {
+    res.sendFile(req.url, { root });
+  } else {
+    next();
+  }
+}
+
+/**
+ * Determines the appropriate resource path, and checks if the specified url 
+ * 
+ * @returns string of the resource path or undefined if there is no match
+ */
+async function getResourcePath(url: string, config: ServeConfig, userAgent: string): Promise<string> {
+  let searchPaths: string[] = [config.wwwDir];
   if (isUserAgentIOS(userAgent)) {
-    resourcePath = path.join(config.rootDir, IOS_PLATFORM_PATH);
+    searchPaths = IOS_PLATFORM_PATHS.map(resourcePath => path.join(config.rootDir, resourcePath));
   } else if (isUserAgentAndroid(userAgent)) {
-    resourcePath = path.join(config.rootDir, ANDROID_PLATFORM_PATH);
+    searchPaths = ANDROID_PLATFORM_PATHS.map(resourcePath => path.join(config.rootDir, resourcePath));
   }
 
-  fs.stat(path.join(resourcePath, req.url), (err, stats) => {
-    if (err) {
-      return next();
-    }
-    res.sendFile(req.url, { root: resourcePath });
+  for (let i = 0; i < searchPaths.length; i++) {
+    let checkPath = path.join(searchPaths[i], url);
+    try {
+      let result = await checkFile(checkPath);
+      return searchPaths[i];
+    } catch (e) { }
+  }
+}
+
+/**
+ * Checks if a file exists (responds to stat)
+ */
+function checkFile(filePath: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    fs.stat(filePath, (err: Error, stats: any) => {
+      if (err) {
+        return reject();
+      }
+      resolve();
+    });
   });
 }
 
-
-
-function isUserAgentIOS(ua: string) {
+function isUserAgentIOS(ua: string): boolean {
   ua = ua.toLowerCase();
   return (ua.indexOf('iphone') > -1 || ua.indexOf('ipad') > -1 || ua.indexOf('ipod') > -1);
 }
 
-function isUserAgentAndroid(ua: string) {
+function isUserAgentAndroid(ua: string): boolean {
   ua = ua.toLowerCase();
   return ua.indexOf('android') > -1;
 }

--- a/src/dev-server/serve-config.ts
+++ b/src/dev-server/serve-config.ts
@@ -22,5 +22,8 @@ export interface ServeConfig {
 export const LOGGER_DIR = '__ion-dev-server';
 export const IONIC_LAB_URL = '/ionic-lab';
 
-export const IOS_PLATFORM_PATH = path.join('platforms', 'ios', 'www');
-export const ANDROID_PLATFORM_PATH = path.join('platforms', 'android', 'assets', 'www');
+export const IOS_PLATFORM_PATHS = [path.join('platforms', 'ios', 'www')];
+export const ANDROID_PLATFORM_PATHS = [
+  path.join('platforms', 'android', 'assets', 'www'),
+  path.join('platforms', 'android', 'app', 'src', 'main', 'assets', 'www')
+];


### PR DESCRIPTION
#### Short description of what this resolves:

Native plugins do not work with the live server for users using Cordova 8. The current path in the config is valid for Cordova < 8. However, if you install ionic today following the directions on the site you get Cordova 8 by default and therefore the live server can't find cordova. Anything attempting to do native operations results in the error message: `Cordova is not available. Make sure to include cordova.js or run in a device/simulator (running in emulator)`

This has been broken since at least this [11/26/2016 Stack Overflow post](https://stackoverflow.com/questions/40815183/ionic-2-cordova-is-not-available-make-sure-to-include-cordova-js-or-run-in-a-d)

To maintain backward compatibility for Cordova 7 I've changed the platform path variables to arrays of strings and included both possible platform paths.

#### Changes proposed in this pull request:

- Add support for searching multiple platform paths to express middleware
- Add Cordova 8+ android platform path value in server config

**Fixes**:
- #1391 
- [ionic-team/ionic #13737](https://github.com/ionic-team/ionic/issues/13737)
