### PR TITLE
Fixes error to extract constructor name using build --prod

### DIFF
--- a/config/uglifyjs.config.js
+++ b/config/uglifyjs.config.js
@@ -13,6 +13,7 @@ module.exports = {
    */
   compress: {
     toplevel: true,
-    pure_getters: true
+    pure_getters: true,
+    keep_fnames: true
   }
 };


### PR DESCRIPTION
#### Short description of what this resolves:
Fixes error to extract constructor name using build --prod

**Fixes**: 
When we needs extract constructor name from class, (like migrations), usinb build --prod the
uglify process can't do it.

Example
 ```typescript
class  m201707121646_create_post {
   up(): Array<string> {
        return [
          `ALTER TABLE "post" ALTER COLUMN "title" RENAME TO "name"`,
          `ALTER TABLE "post" ADD COLUMN "category_id" INTEGER`
        ];
    }
}

const MIGRATIONS: Array<any> = [
  m201707121646_criar_pessoa
];

MIGRATIONS.forEach((migration) => {
      const instance = new migration();
      console.log((<any>instance).constructor.name);    
}
  


