### PR TITLE
Fix for 1132: Component HTML template not updated when saved

### DIFF
--- a/src/template.ts
+++ b/src/template.ts
@@ -22,13 +22,12 @@ export function templateUpdate(changedFiles: ChangedFile[], context: BuildContex
       if (!updateCorrespondingJsFile(context, file.content, changedTemplateFile.filePath)) {
         throw new Error(`Failed to inline template ${changedTemplateFile.filePath}`);
       }
-      // find the corresponding bundle
+      // find the corresponding bundles
       for (const bundleFile of bundleFiles) {
         const newContent = replaceExistingJsTemplate(bundleFile.content, file.content, changedTemplateFile.filePath);
         if (newContent && newContent !== bundleFile.content) {
           context.fileCache.set(bundleFile.path, { path: bundleFile.path, content: newContent});
           writeFileSync(bundleFile.path, newContent);
-          break;
         }
       }
     }


### PR DESCRIPTION
#### Short description of what this resolves:
HTML template of components is not updated by ionic serve after saving the file.
When a module is shared among multiple modules, e.g., a components module, the component template is present in multiple bundle files, so the template should be replaced in all bundle files.

#### Changes proposed in this pull request:
Instead of only replacing the template in the first matching bundle file, replace it in all matched bundle files. So removing the `break` fixes this.

**Fixes**: #1132 
