### PR TITLE
updating @angular-devkit/build-opitmizer to fix issue #3324

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "main": "dist/index.js",
   "dependencies": {
-    "@angular-devkit/build-optimizer": "0.0.35",
+    "@angular-devkit/build-optimizer": "0.6.8",
     "autoprefixer": "^7.2.6",
     "chalk": "^2.4.0",
     "chokidar": "^1.7.0",


### PR DESCRIPTION
#### Short description of what this resolves:

Newer versions of firebase-js-sdk will not complete a production build. 
Any version after @firebase/database 0.2.1 will freeze with a memory leak during either a iOS or Android production build.

#### Changes proposed in this pull request:

Updating the package.json to use the latest version of @angular-devkit/build-optimizer,
version 0.6.8 resolves the issue and the --prod flag will work and run the optimizejs flag without hanging.

-
-
-

**Fixes**: #
