### PR TITLE
Update Webpack to 3.12.0 to resolve AoT build issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "tslint": "^5.8.0",
     "tslint-eslint-rules": "^4.1.1",
     "uglify-es": "3.2.2",
-    "webpack": "3.8.1",
+    "webpack": "3.12.0",
     "ws": "3.3.2",
     "xml2js": "^0.4.19"
   },


### PR DESCRIPTION
#### Short description of what this resolves:

The version 3.8.1 of Webpack doesn't have the fixe [#6407](https://github.com/webpack/webpack/issues/6407) which fix the build in AoT for multilingual application.

#### Changes proposed in this pull request:

- Update the version of Webpack to 3.12.0
