### PR TITLE
Bump node-sass to 4.9.3 to fix security warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "fs-extra": "^4.0.2",
     "glob": "^7.1.2",
     "json-loader": "^0.5.7",
-    "node-sass": "4.9.0",
+    "node-sass": "4.9.3",
     "os-name": "^2.0.1",
     "postcss": "^6.0.21",
     "proxy-middleware": "^0.15.0",


### PR DESCRIPTION
This should fix the security warnings `npm audit` reports (related to the `hoek` library).