### PR TITLE
chore(deps): bump node-sass to 4.10.0 to fix security warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "fs-extra": "^4.0.2",
     "glob": "^7.1.2",
     "json-loader": "^0.5.7",
-    "node-sass": "4.9.3",
+    "node-sass": "^4.10.0",
     "os-name": "^2.0.1",
     "postcss": "^6.0.21",
     "proxy-middleware": "^0.15.0",


### PR DESCRIPTION
in node-sass 4.10 required version of package request was updated from v2.79.0 to v2.88.0:
    - vulnerable package tunnel-agent v0.4.3 updated to v0.6.0 (https://github.com/request/request/commit/fa48e67578a3c43f83c9e4e9339440e8dbbcf6f5)
    - vulnerable package hoek removed (https://github.com/request/request/commit/a6741d415aba31cd01e9c4544c96f84ea6ed11e3)