### PR TITLE
Add support for symlinks

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -75,7 +75,8 @@ var devConfig = {
 
   resolve: {
     extensions: ['.ts', '.js', '.json'],
-    modules: [path.resolve('node_modules')]
+    modules: [path.resolve('node_modules')],
+    symlinks: false
   },
 
   module: {
@@ -122,7 +123,8 @@ var prodConfig = {
 
   resolve: {
     extensions: ['.ts', '.js', '.json'],
-    modules: [path.resolve('node_modules')]
+    modules: [path.resolve('node_modules')],
+    symlinks: false
   },
 
   module: {

--- a/src/util/glob-util.ts
+++ b/src/util/glob-util.ts
@@ -29,6 +29,7 @@ export function generateGlobTasks(patterns: string[], opts: any) {
     statCache: Object.create(null),
     realpathCache: Object.create(null),
     symlinks: Object.create(null),
+    follow: true,
     ignore: []
   }, opts);
 


### PR DESCRIPTION
#### Short description of what this resolves:
In order to share code among projects, using symlinks is one of the options. However, Ionic does not support symlinks out of the box. This commit will add this support.

#### Changes proposed in this pull request:
- Add symlink support in the webpack configuration
By the webpack configuration `symlinks` to false, the files will be looked for in the symlinked location instead of the real location. 

- Add symlink support to the glob-util
I found that when using symlinks, the files were not updated when running `ionic serve`. By debugging for a few hours I found that a tool called `glob` was not resolving symlinked directories. A symlinked directory was treated as a file. Therefore only the first file (e.g., shared/shared.module.ts) was cached in the context file cache and not the files in underlying directories. This was causing the transpiler not to update those files when they were changed. By setting `follow: true` this problem is resolved. 

#### Example
I have included a minimal example project. The README.md includes the two instruction you'll have to follow to make this work. 

[ionic-symllink-example.zip](https://github.com/ionic-team/ionic-app-scripts/files/2942921/ionic-symllink-example.zip)

**Fixes**: #635 
