### PR TITLE
TSLint: Support for excluding files and folders (simplified)

### DIFF
--- a/src/lint/lint-factory.ts
+++ b/src/lint/lint-factory.ts
@@ -79,7 +79,10 @@ export function getFileNames(context: BuildContext, program: Program): string[] 
  */
 export function getTsLintConfig(tsLintConfig: string, linterOptions?: LinterOptions): LinterConfig {
   const config = Configuration.loadConfigurationFromPath(tsLintConfig);
-  Object.assign(config, isObject(linterOptions) ? {linterOptions} : {});
+  const configLinterOptions = isObject(config.linterOptions) ? config.linterOptions : {}
+  const ionicLinterOptions = isObject(linterOptions) ? linterOptions : {}
+  Object.assign(configLinterOptions, ionicLinterOptions);
+  Object.assign(config, isObject(linterOptions) ? {linterOptions: configLinterOptions} : {});
   return config;
 }
 


### PR DESCRIPTION


#### Short description of what this resolves:
Sometimes we might want to exclude files from linting, i.e. autogenerated files, stub files etc. TSLint does support this in its tslint.json file, but ionic-app-scripts overwrite that field with {typeCheck:false}

There's another pull-request https://github.com/ionic-team/ionic-app-scripts/pull/1204 for the same purpose, but it is a bit more verbose, a bit outdated and in case of appearing new linter options supported by TSLint we will apply the same fixes once again


#### Changes proposed in this pull request:

- Use Object.assign to add `{typeCheck: false}` to `linterOptions` and preserve original options
