### PR TITLE
Preserve original linterOptions in tslint.json

### DIFF
--- a/src/lint/lint-factory.spec.ts
+++ b/src/lint/lint-factory.spec.ts
@@ -55,6 +55,20 @@ describe('lint factory', () => {
         typeCheck: true
       });
     });
+
+    it('should extend configuration with {linterOptions} and preserve original linterOptions', () => {
+      const tsConfigFilePath = 'tsconfig.json';
+      const mockConfig = {rulesDirectory: ['node_modules/@ionic'], linterOptions: {exclude: ['vendor/**']}};
+      spyOn(Configuration, Configuration.loadConfigurationFromPath.name).and.returnValue(mockConfig);
+      const config = getTsLintConfig(tsConfigFilePath, {
+        typeCheck: true
+      });
+
+      expect(config.linterOptions).toEqual({
+        typeCheck: true,
+        exclude: ['vendor/**']
+      });
+    });
   });
 
   describe('createLinter()', () => {

--- a/src/lint/lint-factory.ts
+++ b/src/lint/lint-factory.ts
@@ -79,7 +79,13 @@ export function getFileNames(context: BuildContext, program: Program): string[] 
  */
 export function getTsLintConfig(tsLintConfig: string, linterOptions?: LinterOptions): LinterConfig {
   const config = Configuration.loadConfigurationFromPath(tsLintConfig);
-  Object.assign(config, isObject(linterOptions) ? {linterOptions} : {});
+  if (!isObject(linterOptions)) {
+    return config;
+  }
+  if (!config.linterOptions) {
+    config.linterOptions = {};
+  }
+  Object.assign(config.linterOptions, linterOptions);
   return config;
 }
 


### PR DESCRIPTION
#### Short description of what this resolves:
tslint.json may specify linterOptions.
For example, a certain directory may be excluded from linting.
However, when linter is run as part of ionic-app-scripts, linterOptions
are fully overwritten, and exclusion is no longer performed.

#### Changes proposed in this pull request:
This changelist addresses the problem above by preserving original
linterOptions, and extending them with the requested ones.
